### PR TITLE
Feature extend backslash api

### DIFF
--- a/flask_app/blueprints/rest.py
+++ b/flask_app/blueprints/rest.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member
 import math
 import os
+import json
 
 import requests
 
@@ -59,9 +60,17 @@ class SessionMetadataResource(ModelResource):
             returned = returned.filter(SessionMetadata.key == args.key)
 
         # filter by value
-        # TODO: Allow generic parsing of jsonb column data
+        # TODO: Allow generic parsing of jsonb column data (need to add "" around string )
         if args.value is not None:
-            returned = returned.filter(SessionMetadata.metadata_item == args.value)
+            
+            # convert strings to json string (add "")
+            value = json.dumps(args.value)
+
+            # if value is an integer do not cast
+            if args.value.isnumeric():
+                value = args.value
+
+            returned = returned.filter(SessionMetadata.metadata_item == value)
 
         return returned
 

--- a/flask_app/models.py
+++ b/flask_app/models.py
@@ -497,7 +497,7 @@ class Test(db.Model, TypenameMixin, StatusPredicatesMixin, HasSubjectsMixin, Use
 _METADATA_KEY_TYPE = db.String(1024)
 
 
-class TestMetadata(db.Model):
+class TestMetadata(db.Model, TypenameMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     test_id = db.Column(
@@ -506,7 +506,7 @@ class TestMetadata(db.Model):
     metadata_item = db.Column(JSONB)
 
 
-class SessionMetadata(db.Model):
+class SessionMetadata(db.Model, TypenameMixin):
 
     id = db.Column(db.Integer, primary_key=True)
     session_id = db.Column(


### PR DESCRIPTION
# Background

As part of requirements tracking we want the ability to query the backslash server for past test runs matching a certain commit, in order to auto-generate a report mapping requirements to tests tagged with those requirements. However, the session ```scm_revision``` lives in the ```SessionMetadata``` and the test tags live in the ```TestMetadata```.  Currently, the backslash api does not allow for querying Test and Session Metadata directly (via REST API) which is necessary for being able to (A) get all sessions with a specific commit (B) get all tests with a specific tag. 

# Description

The objective of this PR is to extend the backslash API to allow us to get Session and Test Metadata. The Session's associated commit is stored in its metadata, thus, in order to get all the tests under a certain commit, we must be able to filter through SessionMetadata to get all session ids associated with a commit. From there, we can get all tests per session thus getting all tests under a certain commit. In addition, we need access to TestMetadata since test tags are stored in TestMetadata. Ultimately, we want to map each requirement to a list of tests that are tagged with that requirement id. 

The following endpoints have been added:

```/session-metadata, /session-metadata/<object_id>```

### Parameters

| name | type | in | description |
|------|------|---|------------|
|```object_id```| ```string``` | path | The unique id of the session metadata item |
| ```id``` | ```int``` | query | Get all session metadata items associated with session id. |
| ```key``` | ```string``` | query | Get all session metadata items with key. |
| ```value``` | ```string``` | query | Get all session metadata items with matching value. |

```/test-metadata```

### Parameters

| name | type | in | description |
|------|------|---|------------|
|```tags```| ```string``` | query | Filter test metadata by matching tags. Can chain multiple tags filters to get all test metadata items for all tags |
| ```key``` | ```string``` | query | Filter test metadata by key. |
| ```ids``` | ```int``` | query | Filter test metadata by test ids. Can chain multiple ids filters to get all test metadata items for all test ids.  |



# Verification

Describe how you know the work was completed successfully and link supporting evidence
